### PR TITLE
Some bug fixes

### DIFF
--- a/BigFloat.Core.csproj
+++ b/BigFloat.Core.csproj
@@ -10,14 +10,7 @@
     <PackageProjectUrl>https://github.com/FaustVX/BigFloat</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/FaustVX/BigFloat/blob/master/LICENSE</PackageLicenseUrl>
     <PackageTags>C# CSharp dotnet standard</PackageTags>
-    <Version>1.1.0</Version>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <LangVersion>7.2</LangVersion>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <Version>1.2</Version>
     <LangVersion>7.2</LangVersion>
   </PropertyGroup>
 

--- a/BigFloat.UnitTest/BigFloatUnitTest.cs
+++ b/BigFloat.UnitTest/BigFloatUnitTest.cs
@@ -1,8 +1,9 @@
 using System;
+using System.Numerics;
 using Xunit;
 using Xunit.Abstractions;
 
-namespace BigFloat.UnitTest
+namespace UnitTests
 {
     public class BigFloatUnitTest
     {
@@ -21,7 +22,7 @@ namespace BigFloat.UnitTest
                 var testDigits = (decimal)(Math.PI * Math.Pow(10.0, exp));
                 output.WriteLine(testDigits.ToString());
 
-                var bigFloat = new System.Numerics.BigFloat(testDigits);
+                var bigFloat = new BigFloat(testDigits);
                 var str = bigFloat.ToString();
                 output.WriteLine(str);
 
@@ -38,13 +39,44 @@ namespace BigFloat.UnitTest
                 var testDigits = (decimal)(Math.Pow(10.0, exp));
                 output.WriteLine(testDigits.ToString());
 
-                var bigFloat = new System.Numerics.BigFloat(testDigits);
+                var bigFloat = new BigFloat(testDigits);
                 var str = bigFloat.ToString(20, true);
                 output.WriteLine(str);
 
                 var compare = decimal.Parse(str);
                 Assert.Equal(testDigits, compare);
             }
+        }
+
+        [Fact]
+        public void Signing()
+        {
+            var a = new BigFloat(new BigInteger(1), new BigInteger(1));
+            var b = new BigFloat(new BigInteger(-1), new BigInteger(-1));
+
+            Assert.Equal(1, a);
+            Assert.Equal(1, b);
+
+            var c = new BigFloat(new BigInteger(-1), new BigInteger(1));
+            var d = new BigFloat(new BigInteger(1), new BigInteger(-1));
+
+            Assert.Equal(-1, c);
+            Assert.Equal(-1, d);
+        }
+
+        [Fact]
+        public void Equality()
+        {
+            var a = new BigFloat(new BigInteger(1), new BigInteger(1));
+            var b = new BigFloat(new BigInteger(2), new BigInteger(2));
+            Assert.Equal(b, a);
+
+            var c = new BigFloat(new BigInteger(-1), new BigInteger(-1));
+            Assert.Equal(c, a);
+            
+            var e = new BigFloat(new BigInteger(-1), new BigInteger(1));
+            var f = new BigFloat(new BigInteger(2), new BigInteger(-2));
+            Assert.Equal(e, f);
         }
     }
 }

--- a/BigFloat.UnitTest/BigFloatUnitTest.cs
+++ b/BigFloat.UnitTest/BigFloatUnitTest.cs
@@ -73,7 +73,7 @@ namespace UnitTests
 
             var c = new BigFloat(new BigInteger(-1), new BigInteger(-1));
             Assert.Equal(c, a);
-            
+
             var e = new BigFloat(new BigInteger(-1), new BigInteger(1));
             var f = new BigFloat(new BigInteger(2), new BigInteger(-2));
             Assert.Equal(e, f);

--- a/BigFloat.cs
+++ b/BigFloat.cs
@@ -40,7 +40,6 @@ namespace System.Numerics
         //     Denominator = BigInteger.One;
         // }
 
-        //[Obsolete("Use BigFloat.Parse instead.")]
         private BigFloat(string value)
         {
             var bf = Parse(value);

--- a/BigFloat.cs
+++ b/BigFloat.cs
@@ -53,7 +53,7 @@ namespace System.Numerics
             Numerator = numerator;
             if (denominator == 0)
                 throw new ArgumentException("denominator equals 0");
-            Denominator = BigInteger.Abs(denominator);
+            Denominator = denominator;
         }
 
         public BigFloat(BigInteger value)
@@ -442,7 +442,7 @@ namespace System.Numerics
         }
 
         public bool Equals(BigFloat other)
-            => other.Numerator == Numerator && other.Denominator == Denominator;
+            => other.Numerator * Denominator == Numerator * other.Denominator;
 
         public override int GetHashCode()
             => (Numerator, Denominator).GetHashCode();

--- a/BigFloat.cs
+++ b/BigFloat.cs
@@ -40,7 +40,7 @@ namespace System.Numerics
         //     Denominator = BigInteger.One;
         // }
 
-        [Obsolete("Use BigFloat.Parse instead.")]
+        //[Obsolete("Use BigFloat.Parse instead.")]
         private BigFloat(string value)
         {
             var bf = Parse(value);
@@ -299,7 +299,7 @@ namespace System.Numerics
                 throw new ArgumentNullException(nameof(value));
 
             value = value.Trim();
-            var nf = CultureInfo.CurrentUICulture.NumberFormat;
+            var nf = Threading.Thread.CurrentThread.CurrentCulture.NumberFormat;
             value = value.Replace(nf.NumberGroupSeparator, "");
             var pos = value.IndexOf(nf.NumberDecimalSeparator);
             value = value.Replace(nf.NumberDecimalSeparator, "");
@@ -359,7 +359,7 @@ namespace System.Numerics
         public string ToString(int precision, bool trailingZeros = false)
         {
             var value = Factor(this);
-            var nf = CultureInfo.CurrentUICulture.NumberFormat;
+            var nf = Threading.Thread.CurrentThread.CurrentCulture.NumberFormat;
 
             var result = BigInteger.DivRem(value.Numerator, value.Denominator, out var remainder);
 


### PR DESCRIPTION
1) Parse and ToString used UiCulture. e.g. double.ToString() uses ThreadCulture, which resulted in parsing the wrong number.
2) Sign is determined by both (Nominator and Denominator).
* 1/1 == -1/-1
* 1/-1 == -1/1
3) Equality is always given, when the relation between Nominator and Denominator are the same 
* n1/d1 == n2/d2, if n2 == X * n1 and d2 = X * d1
* 1/1 == 2/2
* -1/-1 == 2/2
* -1/1 == -2/2
* 1/-1 == -2/2
* ...
easiest, whithout doing the division is to compare n1 * d2 == n2 * d1